### PR TITLE
Increase minimum node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^4.8.4"
       },
       "engines": {
-        "node": ">=12 <18"
+        "node": ">=12 <22"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
swagger-typescript can't be installed to Node LTS version due to this constraint. I'm not sure if this breaks anything tho.